### PR TITLE
Fix passing args to npm on install

### DIFF
--- a/eclass/node.eclass
+++ b/eclass/node.eclass
@@ -158,7 +158,7 @@ node_src_compile() {
 	"${NPM}" config set audit false || die
 	"${NPM}" config set fund false || die
 
-	"${NPM}" install --global --loglevel verbose "${NPM_FLAGS}" || die
+	"${NPM}" install --global --loglevel verbose ${NPM_FLAGS} || die
 }
 
 node_src_install() {


### PR DESCRIPTION
quoting ${NPM_ARGS} passes the empty string "" to `npm install` which
eventually gets resolve to undefined, resulting in the package
`undefined` attempting to be installed.